### PR TITLE
Fix PowerShell 5.1 parse failure in HTML report generation

### DIFF
--- a/DeployWorkstation.ps1
+++ b/DeployWorkstation.ps1
@@ -1016,16 +1016,13 @@ function Export-HtmlReport {
     $os          = Get-CimInstance Win32_OperatingSystem
     $cpu         = ConvertTo-HtmlSafe (Get-CimInstance Win32_Processor | Select-Object -First 1).Name
     $osCaption   = ConvertTo-HtmlSafe $os.Caption
-    $osEdition   = ConvertTo-HtmlSafe (
-        switch -Regex ($os.Caption) {
-            '\bHome\b'       { 'Home'        }
-            '\bPro\b'        { 'Pro'         }
-            '\bEnterprise\b' { 'Enterprise'  }
-            '\bEducation\b'  { 'Education'   }
-            '\bServer\b'     { 'Server'      }
-            default          { 'Unknown'     }
-        }
-    )
+    $osEditionRaw = 'Unknown'
+    if ($os.Caption -match '\bHome\b') { $osEditionRaw = 'Home' }
+    elseif ($os.Caption -match '\bPro\b') { $osEditionRaw = 'Pro' }
+    elseif ($os.Caption -match '\bEnterprise\b') { $osEditionRaw = 'Enterprise' }
+    elseif ($os.Caption -match '\bEducation\b') { $osEditionRaw = 'Education' }
+    elseif ($os.Caption -match '\bServer\b') { $osEditionRaw = 'Server' }
+    $osEdition   = ConvertTo-HtmlSafe $osEditionRaw
     $osBuild     = $script:OsBuild
     $ramGB       = [math]::Round($os.TotalVisibleMemorySize / 1MB, 1)
     $uptimeHrs   = [math]::Round(((Get-Date) - $os.LastBootUpTime).TotalHours, 1)


### PR DESCRIPTION
### Motivation
- Replace a `switch -Regex` expression in `Export-HtmlReport` with explicit `if/elseif` checks to avoid a parser error (`Unexpected token '{'`) on Windows PowerShell 5.1 while preserving existing OS edition mappings.

### Description
- Rewrote the inline `switch -Regex` that derived `$osEdition` into a simple assignment ` $osEditionRaw` followed by `if/elseif` matches for `Home`, `Pro`, `Enterprise`, `Education`, and `Server`, then pass the result through `ConvertTo-HtmlSafe` in `DeployWorkstation.ps1`.

### Testing
- Executed the automated patch script (`python`) which reported `patched`, and verified the updated lines in `DeployWorkstation.ps1` using `nl`/`sed` to confirm the new `if/elseif` block; running Windows PowerShell 5.1 was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c411b8a3848325a80616e269018200)