### PR TITLE
Add .cmd compatibility launcher and make Pester tests cross-platform safe

### DIFF
--- a/DeployWorkstation.cmd
+++ b/DeployWorkstation.cmd
@@ -1,0 +1,7 @@
+@echo off
+REM Compatibility launcher for users/docs that still invoke DeployWorkstation.cmd
+REM Delegates to DeployWorkstation.bat in the same folder.
+setlocal
+set "script_dir=%~dp0"
+call "%script_dir%DeployWorkstation.bat" %*
+exit /b %errorlevel%

--- a/tests/DeployWorkstation.Tests.ps1
+++ b/tests/DeployWorkstation.Tests.ps1
@@ -6,44 +6,58 @@ if (-not (Get-Module -Name Pester -ListAvailable)) {
 Describe "DeployWorkstation Prerequisites" {
     Context "System Requirements" {
         It "Should be running on Windows 10 or 11" {
+            if (-not $IsWindows) {
+                Set-ItResult -Skipped -Because "Windows-only deployment validation"
+                return
+            }
+
             $osVersion = [System.Environment]::OSVersion.Version
             $osVersion.Major | Should -BeGreaterOrEqual 10
         }
-        
+
         It "Should have PowerShell 5.1 or later" {
             $PSVersionTable.PSVersion.Major | Should -BeGreaterOrEqual 5
         }
-        
+
         It "Should have internet connectivity" {
+            if (-not $IsWindows) {
+                Set-ItResult -Skipped -Because "Windows-only deployment validation"
+                return
+            }
+
             Test-NetConnection -ComputerName "8.8.8.8" -Port 53 -InformationLevel Quiet | Should -Be $true
         }
     }
-    
+
     Context "File Structure" {
         It "Should have main script file" {
             Test-Path ".\DeployWorkstation.ps1" | Should -Be $true
         }
-        
+
         It "Should have launcher script" {
+            Test-Path ".\DeployWorkstation.bat" | Should -Be $true
+        }
+
+        It "Should have compatibility launcher script" {
             Test-Path ".\DeployWorkstation.cmd" | Should -Be $true
         }
-        
+
         It "Should have configuration directory" {
-            Test-Path ".\Config" | Should -Be $true
+            Test-Path ".\config" | Should -Be $true
         }
     }
 }
 
 Describe "Configuration Validation" {
     Context "JSON Configuration Files" {
-        $configFiles = Get-ChildItem ".\Config\Examples\*.json" -ErrorAction SilentlyContinue
-        
+        $configFiles = Get-ChildItem ".\config\Examples\*.json" -ErrorAction SilentlyContinue
+
         foreach ($file in $configFiles) {
             It "Should have valid JSON format: $($file.Name)" {
                 { Get-Content $file.FullName | ConvertFrom-Json } | Should -Not -Throw
             }
         }
-        
+
         It "Should have at least one example configuration" {
             $configFiles.Count | Should -BeGreaterThan 0
         }
@@ -53,10 +67,20 @@ Describe "Configuration Validation" {
 Describe "WinGet Availability" {
     Context "Package Manager" {
         It "Should have WinGet available" {
+            if (-not $IsWindows) {
+                Set-ItResult -Skipped -Because "Windows-only deployment validation"
+                return
+            }
+
             { winget --version } | Should -Not -Throw
         }
-        
+
         It "Should be able to search for packages" {
+            if (-not $IsWindows) {
+                Set-ItResult -Skipped -Because "Windows-only deployment validation"
+                return
+            }
+
             $result = winget search "Google.Chrome" --exact
             $result | Should -Not -BeNullOrEmpty
         }


### PR DESCRIPTION
### Motivation
- Provide a compatibility entrypoint so legacy docs/scripts that invoke a `.cmd` file continue to work without modification. 
- Prevent the test suite from failing when run in non-Windows CI/containers by avoiding Windows-only checks that would error outside Windows. 

### Description
- Added `DeployWorkstation.cmd`, a small compatibility launcher that forwards all arguments to `DeployWorkstation.bat` in the same folder. 
- Updated `tests/DeployWorkstation.Tests.ps1` to check for both the real launcher (`DeployWorkstation.bat`) and the new compatibility launcher (`DeployWorkstation.cmd`). 
- Hardened tests by skipping Windows-only checks (`OS`, `winget`, `Test-NetConnection`) when the environment is not Windows and corrected repository path casing to `.esource
ame` style (`.\config\nExamples` used in the tests). 

### Testing
- Ran a repository validation script (`python`) that parsed all JSON files under `config/Examples` and verified expected launcher flow markers in `DeployWorkstation.bat` and delegation behavior in `DeployWorkstation.cmd`, and those checks passed. 
- Executed a file-content and JSON validation run which reported `JSON validation passed`, `Batch launcher flow checks passed`, and `CMD compatibility launcher checks passed`. 
- Attempted to run native PowerShell/Pester tests but `pwsh` is not installed in this container so Pester execution could not be performed here and Windows-only runtime checks remain unexecuted (the tests are written to skip those checks on non-Windows environments).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c412677e10832595b6881b0dfe4f2f)